### PR TITLE
chore(ci): use buildjet runners for gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
   slither:
     name: Slither
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Switch to using [BuildJet](https://buildjet.com/for-github-actions) managed performance runners instead of Azure.  The biggest improvement is with the slither action, with runtime decreasing from 3m 31s to 2m 16s (~35.5% reduction).

Before:
<img width="494" alt="Screenshot 2023-07-19 at 8 58 54 AM" src="https://github.com/Storm-Labs-Inc/smart-contracts-core/assets/972382/814e4938-844e-491d-84ed-2d872353ecf9">

After:
<img width="838" alt="Screenshot 2023-07-19 at 9 11 22 AM" src="https://github.com/Storm-Labs-Inc/smart-contracts-core/assets/972382/c1d71799-97b5-4d2b-b507-85d26e96a5c0">