### PR TITLE
test(wip): add coveYFI invariant tests

### DIFF
--- a/test/CoveYFI.t.sol
+++ b/test/CoveYFI.t.sol
@@ -23,6 +23,11 @@ contract CoveYFITest is YearnV3BaseTest {
 
         vm.prank(admin);
         coveYFI = new CoveYFI(MAINNET_YFI, yearnStakingDelegate);
+
+        // TODO: refactor into fork/integration/invariant directories
+        // Invariant test setup
+        targetContract(address(coveYFI));
+        targetSender(address(bob));
     }
 
     function testFuzz_constructor(address noAdminAddress) public {
@@ -104,5 +109,15 @@ contract CoveYFITest is YearnV3BaseTest {
         vm.prank(bob);
         vm.expectRevert("Ownable: caller is not the owner");
         CoveYFI(coveYFI).rescue(IERC20(address(0)), admin, 1e18);
+    }
+
+    // TODO: fix reverts
+    function invariant_no_yfi_balance() external {
+        assertEq(IERC20(MAINNET_YFI).balanceOf(address(this)), 0);
+    }
+
+    // TODO: fix reverts
+    function invariant_veyfi_balance_matches_coveyfi_supply() external {
+        assertEq(IERC20(MAINNET_VE_YFI).balanceOf(address(this)), coveYFI.totalSupply());
     }
 }


### PR DESCRIPTION
## Describe your changes

```
Running 2 tests for test/CoveYFI.t.sol:CoveYFITest
[PASS] invariant_no_yfi_balance() (runs: 256, calls: 3840, reverts: 3131)
Logs:
  Started fork  mainnet  at block  18429780
  with id 0

[PASS] invariant_veyfi_balance_matches_coveyfi_supply() (runs: 256, calls: 3840, reverts: 3133)
Logs:
  Started fork  mainnet  at block  18429780
  with id 0

Test result: ok. 2 passed; 0 failed; 0 skipped; finished in 5.48s

Ran 1 test suites: 2 tests passed, 0 failed, 0 skipped (2 total tests)
```

## Checklist before requesting a review

- [ ] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Newly added functions follow Check-effects-interaction
- [ ] Gas usage has been minimized (ex. Storage variable access is minimized)
