### PR TITLE
fix(YSDRewardsGauge): use convertToShares for correct maxMint return

### DIFF
--- a/src/rewards/YSDRewardsGauge.sol
+++ b/src/rewards/YSDRewardsGauge.sol
@@ -78,7 +78,7 @@ contract YSDRewardsGauge is BaseRewardsGauge {
         if (paused()) {
             return 0;
         }
-        return _availableDepositLimit();
+        return convertToShares(_availableDepositLimit());
     }
 
     function _availableDepositLimit() internal view returns (uint256) {


### PR DESCRIPTION
## Describe your changes

Related: https://github.com/yAudit/cove-report/issues/9#issuecomment-2027524412

* Use `convertToShares()` to convert available asset deposit limit for `maxMint()`

## Checklist before requesting a review

- [x] Title follows [conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Newly added functions follow Check-effects-interaction
- [x] Gas usage has been minimized (ex. Storage variable access is minimized)
